### PR TITLE
Trigger change event on input to ensure forms are updated

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,4 +1,9 @@
 chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     var textField = document.activeElement;
     textField.value = textField.value + message.key;
+
+    // Fire change event so controlled inputs know to update values
+    const changeEvent = document.createEvent("HTMLEvents");
+    changeEvent.initEvent("change", true, true);
+    textField.dispatchEvent(changeEvent);
 });


### PR DESCRIPTION
To update a custom extension:

1. Go to `chrome://extensions/`
2. Click the refresh arrow on the extension card:

<img width="435" alt="Screen Shot 2020-03-10 at 2 04 52 PM" src="https://user-images.githubusercontent.com/2036284/76354498-2c112300-62d8-11ea-83fd-6ccf0369c514.png">

You should be able to right-click the input, select `Paste OTP Token`, submit, and it work.